### PR TITLE
Remove unnecessary functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export class DatabaseDurableObject extends DurableObject {
         try {
             let cursor;
 
-            if (params) {
+            if (params && params.length) {
                 cursor = this.sql.exec(sql, params);
             } else {
                 cursor = this.sql.exec(sql);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,49 +18,16 @@ export class DatabaseDurableObject extends DurableObject {
         this.sql = ctx.storage.sql;
     }
 
-    constructQuery(sql: string, params?: any[]): string {
-        if (!params || params.length === 0) {
-            return sql;
-        }
-    
-        let paramIndex = 0;
-        return sql.replace(/\?/g, () => {
-            if (paramIndex >= params.length) {
-                throw new Error('Not enough parameters provided.');
-            }
-            const param = params[paramIndex++];
-            return this.escapeSqlValue(param);
-        });
-    }
-    
-    escapeSqlValue(value: any): string {
-        if (value === null || value === undefined) {
-            return 'NULL';
-        } else if (typeof value === 'number' || typeof value === 'bigint') {
-            if (!isFinite(value as number)) {
-                throw new Error('Invalid number value.');
-            }
-            return value.toString();
-        } else if (typeof value === 'boolean') {
-            return value ? '1' : '0';
-        } else if (typeof value === 'string') {
-            // Escape single quotes by doubling them
-            return `'${value.replace(/'/g, "''")}'`;
-        } else if (value instanceof Date) {
-            return `'${value.toISOString()}'`;
-        } else if (typeof value === 'object') {
-            // Serialize object or array to JSON string
-            const jsonString = JSON.stringify(value);
-            return `'${jsonString.replace(/'/g, "''")}'`;
-        } else {
-            throw new Error(`Unsupported parameter type: ${typeof value}`);
-        }
-    }
-
     async executeQuery(sql: string, params?: any[]): Promise<any[]> {
         try {
-            const constructedSql = this.constructQuery(sql, params);
-            const cursor = this.sql.exec(constructedSql);
+            let cursor;
+
+            if (params) {
+                cursor = this.sql.exec(sql, params);
+            } else {
+                cursor = this.sql.exec(sql);
+            }
+
             const result = cursor.toArray();
             return result;
         } catch (error) {


### PR DESCRIPTION
Previously was taking the approach of manually escaping SQL based on params input, but seems I simply missed that you can optionally pass in `params` as a second input to `.exec` but only when it exists. Otherwise it will fail if you pass in undefined.

Testing SQL cURL:
```
curl --location --request POST 'https://starbasedb.brayden-b8b.workers.dev/query' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ABC123' \
--data-raw '{
    "sql": "SELECT * FROM artist WHERE artistid=$1;",
    "params": [123]
}'
```

Worth noting that the following code would _not_ work:
```
cursor = this.sql.exec(sql, params ?? []);
```

If the `params` array is valid but empty, it still breaks. It must be like this:
```
if (params && params.length) {
    cursor = this.sql.exec(sql, params);
} else {
    cursor = this.sql.exec(sql);
}
```