### PR TITLE
Transaction support for query batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 <p align="center">
   <i>Open source, scale-to-zero, HTTP SQLite database built on top of <a href="https://developers.cloudflare.com/durable-objects/" target="_blank">Cloudflare Durable Objects</a>.</i>
 </p>
+
+<br />
+<h2>⚡ Features</h2>
+<ul>
+  <li>**HTTPS Endpoints** to interact with your database</li>
+  <li>**Transactions Support **for ACID database interactions</li>
+  <li>**Scale-to-zero Compute** when your database is not in use</li>
+</ul>
+
 <br />
 <h2>📦 How to Deploy</h2>
 <p>Deploying a new SQLite database instance to a Cloudflare Durable Object can be done in a matter of minutes:</p>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,27 @@ curl --location --request POST 'https://starbasedb.YOUR-ID-HERE.workers.dev/quer
 </code>
 </pre>
 
+<h3>Transactions</h3>
+<pre>
+<code>
+curl --location --request POST 'https://starbasedb.YOUR-ID-HERE.workers.dev/query' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer ABC123' \
+--data-raw '{
+    "transaction": [
+        {
+            "sql": "SELECT * FROM artist WHERE artistid=$1;",
+            "params": [123]
+        },
+        {
+            "sql": "SELECT * FROM artist;",
+            "params": []
+        }
+    ]
+}'
+</code>
+</pre>
+
 <br />
 <h2>🤝 Contributing</h2>
 <p>We welcome contributions! Please refer to our <a href="./CONTRIBUTING.md">Contribution Guide</a> for more details.</p>

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export class DatabaseDurableObject extends DurableObject {
         let transactionBookmark: any | null = null;
 
         try {
-            // Create a storage bookmark before starting the transaction
+            // Create a storage bookmark before starting the transaction.
             transactionBookmark = await this.ctx.storage.getCurrentBookmark();
 
             for (const queryObj of queries) {
@@ -62,10 +62,13 @@ export class DatabaseDurableObject extends DurableObject {
         } catch (error) {
             console.error('Transaction Execution Error:', error);
 
+            /**
+             * If an error occurs during the transaction, we can restore the storage to the state
+             * before the transaction began by using the bookmark we created before starting the
+             * transaction.
+             */
             if (transactionBookmark) {
-                // Restore the storage to the bookmark
                 await this.ctx.storage.onNextSessionRestoreBookmark(transactionBookmark);
-                // Abort the current session to rollback
                 await this.ctx.abort();
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,6 @@ export class DatabaseDurableObject extends DurableObject {
             throw new Error('Another transaction is already in progress.');
         }
 
-        console.log('executeTransaction', queries, transactionId);
-
         if (!this.transactionInProgress) {
             // Start the transaction
             this.transactionInProgress = true;
@@ -43,8 +41,6 @@ export class DatabaseDurableObject extends DurableObject {
                 const result = this.executeQuery(sql, params);
                 results.push(result);
             }
-
-            console.log('Results: ', results);
 
             // Transaction successful, reset transaction state
             this.transactionInProgress = false;
@@ -95,8 +91,6 @@ export class DatabaseDurableObject extends DurableObject {
     
             const { sql, params, transaction } = await request.json() as QueryRequest & QueryTransactionRequest;
             const transactionId = crypto.randomUUID();
-
-            console.log('Transaction: ', transaction)
     
             if (Array.isArray(transaction) && transaction.length) {
                 const queries = transaction.map((queryObj: any) => {
@@ -112,7 +106,6 @@ export class DatabaseDurableObject extends DurableObject {
                 });
 
                 const result = await this.executeTransaction(queries, transactionId);
-                console.log('Final Results: ', result);
                 return createResponse(result, undefined, 200);
             } else if (typeof sql !== 'string' || !sql.trim()) {
                 return createResponse(undefined, 'Invalid or empty "sql" field.', 400);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export class DatabaseDurableObject extends DurableObject {
         }
     }
 
-    async executeTransaction(queries: { sql: string; params?: any[] }[]): any[] {
+    async executeTransaction(queries: { sql: string; params?: any[] }[]): Promise<any[]> {
         const results = [];
         let transactionBookmark: any | null = null;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ export type QueryTransactionRequest = {
 }
 
 export type QueryRequest = {
-    sql?: string;
+    sql: string;
     params?: any[];
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
+export type QueryTransactionRequest = {
+    transaction?: QueryRequest[];
+}
+
 export type QueryRequest = {
-    sql: string;
+    sql?: string;
     params?: any[];
 };
 


### PR DESCRIPTION
These code changes add support for proper ACID query transactions on the database. Every query request is added into an execution queue. If a single query fails, it will respond as a failure. If a transaction of queries fail, the state will be restored to how it was prior to the first query in the transaction being executed.

- [X] Adds support for multi-query transactions
- [X] Add an example to the README for multi-query transactions
- [X] Support ACID transactions via event queueing