### PR TITLE
Raw query response support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ curl --location --request POST 'https://starbasedb.YOUR-ID-HERE.workers.dev/quer
 </code>
 </pre>
 
+<h3>Raw Query Response</h3>
+<pre>
+<code>
+curl --location --request POST 'https://starbasedb.YOUR-ID-HERE.workers.dev/query/raw' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer ABC123' \
+--data-raw '{
+    "sql": "SELECT * FROM artist;",
+    "params": []
+}'
+</code>
+</pre>
+
 <br />
 <h2>🤝 Contributing</h2>
 <p>We welcome contributions! Please refer to our <a href="./CONTRIBUTING.md">Contribution Guide</a> for more details.</p>

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -32,22 +32,14 @@ export function executeQuery(sql: string, params: any[] | undefined, isRaw: bool
         let result;
 
         if (isRaw) {
-            const results = cursor.toArray();
-            if (!results.length) {
-                return { columns: [], rows: [], meta: { rows_read: 0, rows_written: 0 } };
-            }
-
-            const columnNames = results.length ? Object.keys(results[0]) : [];
-            const rows = results.map((row: any) => Object.values(row));
-
             result = {
-                columns: columnNames,
-                rows: rows,
+                columns: cursor.columnNames,
+                rows: cursor.raw().toArray(),
                 meta: {
                     rows_read: cursor.rowsRead,
-                    rows_written: cursor.rowsWritten
-                }
-            };
+                    rows_written: cursor.rowsWritten,
+                },
+            };        
         } else {
             result = cursor.toArray();
         }


### PR DESCRIPTION
Users expect query results from a database to come back in an array of objects, where the objects key is the column name and the value is the database row value. It works great for API responses.

Database GUI's expect results differently, in the case 0 rows are returned but still needs to render column names for example. This pull request aims to include a new route `/query/raw` that returns the data in a format for GUI's, an example is shown below.

## Raw Query
```
curl --location --request POST 'https://starbasedb.brayden-b8b.workers.dev/query/raw' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ABC123' \
--data-raw '{
    "sql": "SELECT * FROM artist;",
    "params": []
}'
```

Response:
```
{
    "result": {
        "columns": [
            "artistid",
            "artistname"
        ],
        "rows": [
            [
                123,
                "Alice"
            ],
            [
                456,
                "Bob"
            ],
            [
                789,
                "Charlie"
            ]
        ],
        "meta": {
            "rows_read": 3,
            "rows_written": 0
        }
    }
}
```

## Normal Query
```
curl --location --request POST 'https://starbasedb.brayden-b8b.workers.dev/query' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ABC123' \
--data-raw '{
    "sql": "SELECT * FROM artist;",
    "params": []
}'
```

Response:
```
{
    "result": [
        {
            "artistid": 123,
            "artistname": "Alice"
        },
        {
            "artistid": 456,
            "artistname": "Bob"
        },
        {
            "artistid": 789,
            "artistname": "Charlie"
        }
    ]
}
```