### PR TITLE
Fix type name collision

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,13 +7,13 @@ export type QueryRequest = {
     params?: any[];
 };
 
-export type QueryResponse = {
+export type ServerResponse = {
     result?: any[];
     error?: string;
     status: number;
 }
 
-export function createJSONResponse(data: QueryResponse): Response {
+export function createJSONResponse(data: ServerResponse): Response {
     return new Response(JSON.stringify({
         result: data.result,
     }), {


### PR DESCRIPTION
Previous PR introduced a type definition named `QueryResponse` that pertains more closely to the response of the executed query. Naming this older version to `ServerResponse` as it pertains more to the response from the server back to the client.