### PR TITLE
Include account_id in TOML for install script

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,7 @@
 name = "starbasedb"
 main = "src/index.ts"
 compatibility_date = "2024-09-25"
+account_id = ""
 
 # Workers Logs
 # Docs: https://developers.cloudflare.com/workers/observability/logs/workers-logs/


### PR DESCRIPTION
## Purpose
Without this included, the `install.sh` script from the marketing site does not know where to place the value when prompted into this file.


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] Include the `account_id` for the users Cloudflare account in the Wrangler file

## Verify
<!-- guidance or steps to assist the reviewer -->

- 

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->