### PR TITLE
Allow query deduping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,15 @@ export class DatabaseDurableObject extends DurableObject {
             }
 
             try {
-                const queries = [{ sql, params }];
+                const queries = [{ sql, params, allowQueryDedupe }];
+                // ADD FOR TESTING TO FORCE POPULATE THE OPERATION QUEUE WITH DUPES
+                // enqueueOperation(
+                //     queries,
+                //     false,
+                //     isRaw,
+                //     this.operationQueue,
+                //     () => { return Promise.resolve() }
+                // );
                 const response = await enqueueOperation(
                     queries,
                     false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,15 @@
-export type QueryTransactionRequest = {
-    transaction?: QueryRequest[];
+export type QueryTransaction = {
+    transaction?: Query[];
 }
 
-export type QueryRequest = {
+export type Query = {
+    // The SQL query to execute
     sql: string;
+    // The parameters to pass to the query
     params?: any[];
+    // Whether to allow query deduplication. If a query with the same SQL and parameters is already in the queue, 
+    //the result of the existing query will be returned instead of enqueuing a new operation.
+    allowQueryDedupe?: boolean;
 };
 
 export type ServerResponse = {


### PR DESCRIPTION
## Purpose
Provide support for queries that exist in the query queue to be resolved automatically if an identical query in front of it resolves to expedite the response time of similar queries and reduce overall database load. This is an optional flag you can assign to queries and by default is `FALSE`, you must explicitly opt-in to this behavior.


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [ ] Support an optional parameter in the requests
- [ ] When a similar request is detected on resolution, auto-resolve those if opted in

## Verify
<!-- guidance or steps to assist the reviewer -->

- 

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->