### PR TITLE
Support SQLite file dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
   <li><strong><a href="https://github.com/Brayden/starbasedb?tab=readme-ov-file#web-sockets">Web Socket Connections</a></strong> to query your database with low-latency web sockets</li>
   <li><strong><a href="https://github.com/Brayden/starbasedb?tab=readme-ov-file#transactions">Transactions Support</a></strong> for executing interdependent collections of queries</li>
   <li><strong><a href="https://github.com/Brayden/starbasedb/blob/main/src/literest/README.md">REST API Support</a></strong> automatically included for interacting with your tables</li>
-  <li><strong><a href="https://github.com/Brayden/starbasedb/edit/main/README.md#deploy-a-starbasedb">Database Interface</a></strong> included out of the box deployed with your Cloudflare Worker</li>
+  <li><strong><a href="https://github.com/Brayden/starbasedb?tab=readme-ov-file#sql-dump">Database Interface</a></strong> included out of the box deployed with your Cloudflare Worker</li>
+  <li><strong><a href="https://github.com/Brayden/starbasedb/edit/main/README.md#deploy-a-starbasedb">SQL Export Dump</a></strong> to extract your schema and data into a local file</li>
   <li><strong>Scale-to-zero Compute</strong> to reduce costs when your database is not in use</li>
 </ul>
 <br />
@@ -214,6 +215,17 @@ function sendMessage() {
 
 window.onload = connectWebSocket;
 ```
+
+<h3>SQL Dump</h3>
+You can request a `database_dump.sql` file that exports your database schema and data into a single file.
+
+<pre>
+<code>
+curl --location 'https://starbasedb.YOUR-ID-HERE.workers.dev/dump' \
+--header 'Authorization: Bearer ABC123' 
+--output database_dump.sql
+</code>
+</pre>
 
 <br />
 <h2>Contributing</h2>

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
   <li><strong><a href="https://github.com/Brayden/starbasedb?tab=readme-ov-file#web-sockets">Web Socket Connections</a></strong> to query your database with low-latency web sockets</li>
   <li><strong><a href="https://github.com/Brayden/starbasedb?tab=readme-ov-file#transactions">Transactions Support</a></strong> for executing interdependent collections of queries</li>
   <li><strong><a href="https://github.com/Brayden/starbasedb/blob/main/src/literest/README.md">REST API Support</a></strong> automatically included for interacting with your tables</li>
-  <li><strong><a href="https://github.com/Brayden/starbasedb?tab=readme-ov-file#sql-dump">Database Interface</a></strong> included out of the box deployed with your Cloudflare Worker</li>
-  <li><strong><a href="https://github.com/Brayden/starbasedb/edit/main/README.md#deploy-a-starbasedb">SQL Export Dump</a></strong> to extract your schema and data into a local file</li>
+  <li><strong><a href="https://github.com/Brayden/starbasedb/edit/main/README.md#deploy-a-starbasedb">Database Interface</a></strong> included out of the box deployed with your Cloudflare Worker</li>
+  <li><strong><a href="https://github.com/Brayden/starbasedb?tab=readme-ov-file#sql-dump">Export SQL Dump</a></strong> to extract your schema and data into a local `.sql` file</li>
   <li><strong>Scale-to-zero Compute</strong> to reduce costs when your database is not in use</li>
 </ul>
 <br />

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,14 +226,7 @@ export class DatabaseDurableObject extends DurableObject {
             const headers = new Headers({
                 'Content-Type': 'application/x-sqlite3',
                 'Content-Disposition': 'attachment; filename="database_dump.sql"',
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Methods': 'GET, OPTIONS',
-                'Access-Control-Allow-Headers': 'Content-Type, Authorization'
             });
-
-            if (_.method === 'OPTIONS') {
-                return new Response(null, { headers });
-            }
 
             return new Response(blob, { headers });
         } catch (error: any) {


### PR DESCRIPTION
## Purpose
A request came in for database instances to be able to pull a dump of their database SQLite file to store locally. This contribution intends to allow a user to hit the `/dump` route on their database and receive a `.sql` file downloaded.


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] Allow users to download a `.sql`  file dump of their database schema & contents

## Verify
<!-- guidance or steps to assist the reviewer -->

cURL:
```
curl --location 'https://starbasedb.{YOUR-IDENTIFIER}.workers.dev/dump' \
--header 'Authorization: Bearer ABC123' \
--output database_dump.sql
```

Response:
```
SQLite format 3�
-- Table: sqlite_sequence
CREATE TABLE sqlite_sequence(name,seq);

INSERT INTO sqlite_sequence VALUES ('users', 5);
INSERT INTO sqlite_sequence VALUES ('orders', 5);


-- Table: users
CREATE TABLE users (user_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, email TEXT UNIQUE NOT NULL);

INSERT INTO users VALUES (1, 'Alice', 'alice@example.com');
INSERT INTO users VALUES (2, 'Bob', 'bob@example.com');
INSERT INTO users VALUES (3, 'Charlie', 'charlie@example.com');


-- Table: orders
CREATE TABLE orders (order_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, order_date TEXT NOT NULL, amount REAL NOT NULL, FOREIGN KEY (user_id) REFERENCES users (user_id));

INSERT INTO orders VALUES (1, 1, '2024-10-01', 50.75);
INSERT INTO orders VALUES (2, 1, '2024-10-03', 30);
INSERT INTO orders VALUES (3, 2, '2024-10-05', 99.99);
INSERT INTO orders VALUES (4, 3, '2024-10-06', 20.49);
INSERT INTO orders VALUES (5, 1, '2024-12-01', 50.75);
```

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->