### PR TITLE
After query event hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ build/Release
 
 node_modules/
 jspm_packages/
+.pnpm-lock.yaml
+\*.package-lock.json
 
 # Snowpack dependency directory (https://snowpack.dev/)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { handleApiRequest } from "./api";
 
 const DURABLE_OBJECT_ID = 'sql-durable-object';
 
-interface Env {
+export interface Env {
     AUTHORIZATION_TOKEN: string;
     DATABASE_DURABLE_OBJECT: DurableObjectNamespace;
     REGION: string;
@@ -35,7 +35,7 @@ enum RegionLocationHint {
     ME = 'me', // Middle East
 }
 
-export class DatabaseDurableObject extends DurableObject {
+export class DatabaseDurableObject extends DurableObject<Env> {
     // Durable storage for the SQL database
     public sql: SqlStorage;
 
@@ -89,7 +89,7 @@ export class DatabaseDurableObject extends DurableObject {
                 false,
                 false,
                 this.operationQueue,
-                () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+                () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation, this.env)
             );
 
             return response;
@@ -127,7 +127,7 @@ export class DatabaseDurableObject extends DurableObject {
                         true,
                         isRaw,
                         this.operationQueue,
-                        () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+                        () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation, this.env)
                     );
 
                     return createResponseFromOperationResponse(response);
@@ -147,7 +147,7 @@ export class DatabaseDurableObject extends DurableObject {
                     false,
                     isRaw,
                     this.operationQueue,
-                    () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+                    () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation, this.env)
                 );
                 
                 return createResponseFromOperationResponse(response);
@@ -242,7 +242,7 @@ export class DatabaseDurableObject extends DurableObject {
                 false,
                 false,
                 this.operationQueue,
-                () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+                () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation, this.env)
             );
 
             ws.send(JSON.stringify(response.result));

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,7 +24,7 @@ class_name = "DatabaseDurableObject"
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["DatabaseDurableObject"] # Array of new classes
+new_sqlite_classes = ["DatabaseDurableObject"]
 
 [vars]
 AUTHORIZATION_TOKEN = "ABC123"


### PR DESCRIPTION
## Purpose
Exposing a new hook that is automatically called after a query execution has happened. This hook allows users to place custom logic to handle the results before they are returned back to the user. Situations where this may be useful is when dealing with PII and wanting to verify no information is sent back to the client that shouldn't, or maybe when you want to track how much data is being passed back to the user, audit logs, or more.

You may notice in this PR that we now pass the `Env` around as well so the `afterQuery` function has access to it. This allows developers to be able to create other Workers to handle the logic, and this piece of the code can use the `Env` to access those service bindings. Helps encourage separation of concern code structure.


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] Expose an `afterQuery` function that can manipulate or observe query results before sending back to client.

## Verify
<!-- guidance or steps to assist the reviewer -->

- Verify existing queries work correctly still

```curl
curl --location 'https://starbasedb.YOUR-IDENTIFIER.workers.dev/query' \
--header 'Authorization: Bearer ABC123' \
--header 'Content-Type: application/json' \
--data '{
    "sql": "SELECT * FROM users WHERE user_id=? OR name=?;",
    "params": [1, "Bob"]
}'
```

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->