### PR TITLE
Support both internal and external data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   <li><strong><a href="https://github.com/Brayden/starbasedb/edit/main/README.md#deploy-a-starbasedb">Database Interface</a></strong> included out of the box deployed with your Cloudflare Worker</li>
   <li><strong><a href="https://starbasedb.hashnode.space/default-guide/import-export/sql-dump">Import & Export Data</a></strong> to import & extract your schema and data into a local `.sql`, `.json` or `.csv` file</li>
   <li><strong><a href="https://github.com/Brayden/starbasedb/pull/26">Bindable Microservices</a></strong> via templates to kickstart development and own the logic (e.g. user authentication)</li>
+  <li><strong><a href="https://starbasedb.hashnode.space/default-guide/introduction/connect-external-database">Connect to External Databases</a></strong> such as Postgres and MySQL and access it with the methods above</li>
   <li><strong>Scale-to-zero Compute</strong> to reduce costs when your database is not in use</li>
 </ul>
 <br />

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ You can request a `database_dump.sql` file that exports your database schema and
 <pre>
 <code>
 curl --location 'https://starbasedb.YOUR-ID-HERE.workers.dev/export/dump' \
---header 'Authorization: Bearer ABC123' 
+--header 'Authorization: Bearer ABC123' \
 --output database_dump.sql
 </code>
 </pre>
@@ -232,9 +232,8 @@ curl --location 'https://starbasedb.YOUR-ID-HERE.workers.dev/export/dump' \
 <h3>JSON Data Export</h3>
 <pre>
 <code>
-curl
---location 'https://starbasedb.YOUR-ID-HERE.workers.dev/export/json/users' \
---header 'Authorization: Bearer ABC123'
+curl --location 'https://starbasedb.YOUR-ID-HERE.workers.dev/export/json/users' \
+--header 'Authorization: Bearer ABC123' \
 --output output.json
 </code>
 </pre>
@@ -242,9 +241,8 @@ curl
 <h3>CSV Data Export</h3>
 <pre>
 <code>
-curl
---location 'https://starbasedb.YOUR-ID-HERE.workers.dev/export/csv/users' \
---header 'Authorization: Bearer ABC123'
+curl --location 'https://starbasedb.YOUR-ID-HERE.workers.dev/export/csv/users' \
+--header 'Authorization: Bearer ABC123' \
 --output output.csv
 </code>
 </pre>
@@ -252,8 +250,7 @@ curl
 <h3>SQL Import</h3>
 <pre>
 <code>
-curl 
---location 'https://starbasedb.YOUR-ID-HERE.workers.dev/import/dump' \
+curl --location 'https://starbasedb.YOUR-ID-HERE.workers.dev/import/dump' \
 --header 'Authorization: Bearer ABC123' \
 --form 'sqlFile=@"./Desktop/sqldump.sql"'
 </code>

--- a/src/do.ts
+++ b/src/do.ts
@@ -1,6 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
 import { OperationQueueItem, QueryResponse } from "./operation";
-import { createResponse, QueryRequest, QueryTransactionRequest } from "./utils";
 
 export class DatabaseDurableObject extends DurableObject {
     // Durable storage for the SQL database

--- a/src/do.ts
+++ b/src/do.ts
@@ -1,0 +1,188 @@
+import { DurableObject } from "cloudflare:workers";
+import { OperationQueueItem, QueryResponse } from "./operation";
+import { createResponse, QueryRequest, QueryTransactionRequest } from "./utils";
+
+export class DatabaseDurableObject extends DurableObject {
+    // Durable storage for the SQL database
+    public sql: SqlStorage;
+
+    // Queue of operations to be processed, with each operation containing a list of queries to be executed
+    private operationQueue: Array<OperationQueueItem> = [];
+
+    // Flag to indicate if an operation is currently being processed
+    private processingOperation: { value: boolean } = { value: false };
+
+	/**
+	 * The constructor is invoked once upon creation of the Durable Object, i.e. the first call to
+	 * 	`DurableObjectStub::get` for a given identifier (no-op constructors can be omitted)
+	 *
+	 * @param ctx - The interface for interacting with Durable Object state
+	 * @param env - The interface to reference bindings declared in wrangler.toml
+	 */
+    constructor(ctx: DurableObjectState, env: Env) {
+        super(ctx, env);
+        this.sql = ctx.storage.sql;
+    }
+
+    /**
+     * Execute a raw SQL query on the database, typically used for external requests
+     * from other service bindings (e.g. auth). This serves as an exposed function for
+     * other service bindings to query the database without having to have knowledge of
+     * the current operation queue or processing state.
+     * 
+     * @param sql - The SQL query to execute.
+     * @param params - Optional parameters for the SQL query.
+     * @returns A response containing the query result or an error message.
+     */
+    // async executeExternalQuery(sql: string, params: any[] | undefined): Promise<any> {
+    //     try {
+    //         const queries = [{ sql, params }];
+    //         const response = await enqueueOperation(
+    //             queries,
+    //             false,
+    //             false,
+    //             this.operationQueue,
+    //             () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+    //         );
+
+    //         return response;
+    //     } catch (error: any) {
+    //         console.error('Execute External Query Error:', error);
+    //         return null;
+    //     }
+    // }
+
+    public executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse {
+        console.log('Executing INTERNAL query: ', sql, params, isRaw);
+
+        try {
+            let cursor;
+            
+            if (params && params.length) {
+                cursor = this.sql.exec(sql, ...params);
+            } else {
+                cursor = this.sql.exec(sql);
+            }
+
+            let result;
+
+            if (isRaw) {
+                result = {
+                    columns: cursor.columnNames,
+                    rows: Array.from(cursor.raw()),
+                    meta: {
+                        rows_read: cursor.rowsRead,
+                        rows_written: cursor.rowsWritten,
+                    },
+                };        
+            } else {
+                result = cursor.toArray();
+            }
+
+            return result;
+        } catch (error) {
+            console.error('SQL Execution Error:', error);
+            throw error;
+        }
+    }
+
+    executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean, sqlInstance: any, ctx: any): Promise<any[]> {
+        return ctx.storage.transactionSync(() => {
+            const results = [];
+
+            try {
+                for (const queryObj of queries) {
+                    const { sql, params } = queryObj;
+                    const result = this.executeQuery(sql, params, isRaw);
+                    results.push(result);
+                }
+
+                return results;
+            } catch (error) {
+                console.error('Transaction Execution Error:', error);
+                throw error;
+            }
+        });
+    }
+
+    enqueueOperation(
+        queries: { sql: string; params?: any[] }[],
+        isTransaction: boolean,
+        isRaw: boolean,
+        operationQueue: any[],
+        processNextOperation: () => Promise<void>
+    ): Promise<{ result?: any, error?: string | undefined, status: number }> {
+        const MAX_WAIT_TIME = 25000;
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                reject(createResponse(undefined, 'Operation timed out.', 503));
+            }, MAX_WAIT_TIME);
+
+            operationQueue.push({
+                queries,
+                isTransaction,
+                isRaw,
+                resolve: (value: any) => {
+                    clearTimeout(timeout);
+
+                    resolve({
+                        result: value,
+                        error: undefined,
+                        status: 200
+                    })
+                },
+                reject: (reason?: any) => {
+                    clearTimeout(timeout);
+
+                    reject({
+                        result: undefined,
+                        error: reason ?? 'Operation failed.',
+                        status: 500
+                    })
+                }
+            });
+
+            processNextOperation().catch((err) => {
+                console.error('Error processing operation queue:', err);
+            });
+        });
+    }
+
+    async processNextOperation(
+        sqlInstance: any,
+        operationQueue: OperationQueueItem[],
+        ctx: any,
+        processingOperation: { value: boolean }
+    ) {
+        if (processingOperation.value) {
+            // Already processing an operation
+            return;
+        }
+
+        if (operationQueue.length === 0) {
+            // No operations remaining to process
+            return;
+        }
+
+        processingOperation.value = true;
+        const { queries, isTransaction, isRaw, resolve, reject } = operationQueue.shift()!;
+
+        try {
+            let result;
+
+            if (isTransaction) {
+                result = await this.executeTransaction(queries, isRaw, sqlInstance, ctx);
+            } else {
+                const { sql, params } = queries[0];
+                result = this.executeQuery(sql, params, isRaw);
+            }
+
+            resolve(result);
+        } catch (error: any) {
+            reject(error.message || 'Operation failed.');
+        } finally {
+            processingOperation.value = false;
+            await this.processNextOperation(sqlInstance, operationQueue, ctx, processingOperation);
+        }
+    }
+}

--- a/src/export/csv.ts
+++ b/src/export/csv.ts
@@ -1,15 +1,13 @@
 import { getTableData, createExportResponse } from './index';
 import { createResponse } from '../utils';
+import { DataSource } from '..';
 
 export async function exportTableToCsvRoute(
-    sql: any,
-    operationQueue: any,
-    ctx: any,
-    processingOperation: { value: boolean },
-    tableName: string
+    tableName: string,
+    dataSource: DataSource
 ): Promise<Response> {
     try {
-        const data = await getTableData(sql, operationQueue, ctx, processingOperation, tableName);
+        const data = await getTableData(tableName, dataSource);
 
         if (data === null) {
             return createResponse(undefined, `Table '${tableName}' does not exist.`, 404);

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -1,36 +1,28 @@
-import { enqueueOperation, processNextOperation } from '../operation';
+// import { enqueueOperation, processNextOperation } from '../operation';
+
+import { DataSource } from "..";
+import { executeTransaction } from "../operation";
+
+export async function executeOperation(queries: { sql: string, params?: any[] }[], dataSource: DataSource): Promise<any> {
+    const results: any[] = (await executeTransaction(queries, false, dataSource)) as any[];
+    return results?.length > 0 ? results[0] : undefined;
+}
 
 export async function getTableData(
-    sql: any,
-    operationQueue: any,
-    ctx: any,
-    processingOperation: { value: boolean },
-    tableName: string
+    tableName: string,
+    dataSource: DataSource
 ): Promise<any[] | null> {
     try {
         // Verify if the table exists
-        const tableExistsResult = await enqueueOperation(
-            [{ sql: `SELECT name FROM sqlite_master WHERE type='table' AND name=?;`, params: [tableName] }],
-            false,
-            false,
-            operationQueue,
-            () => processNextOperation(sql, operationQueue, ctx, processingOperation)
-        );
+        const tableExistsResult = await executeOperation([{ sql: `SELECT name FROM sqlite_master WHERE type='table' AND name=?;`, params: [tableName] }], dataSource)
 
-        if (tableExistsResult.result.length === 0) {
+        if (tableExistsResult.length === 0) {
             return null;
         }
 
         // Get table data
-        const dataResult = await enqueueOperation(
-            [{ sql: `SELECT * FROM ${tableName};` }],
-            false,
-            false,
-            operationQueue,
-            () => processNextOperation(sql, operationQueue, ctx, processingOperation)
-        );
-
-        return dataResult.result;
+        const dataResult = await executeOperation([{ sql: `SELECT * FROM ${tableName};` }], dataSource)
+        return dataResult;
     } catch (error: any) {
         console.error('Table Data Fetch Error:', error);
         throw error;

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -1,5 +1,3 @@
-// import { enqueueOperation, processNextOperation } from '../operation';
-
 import { DataSource } from "..";
 import { executeTransaction } from "../operation";
 

--- a/src/export/json.ts
+++ b/src/export/json.ts
@@ -1,15 +1,13 @@
 import { getTableData, createExportResponse } from './index';
 import { createResponse } from '../utils';
+import { DataSource } from '..';
 
 export async function exportTableToJsonRoute(
-    sql: any,
-    operationQueue: any,
-    ctx: any,
-    processingOperation: { value: boolean },
-    tableName: string
+    tableName: string,
+    dataSource: DataSource
 ): Promise<Response> {
     try {
-        const data = await getTableData(sql, operationQueue, ctx, processingOperation, tableName);
+        const data = await getTableData(tableName, dataSource);
 
         if (data === null) {
             return createResponse(undefined, `Table '${tableName}' does not exist.`, 404);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,9 +1,15 @@
-import { DataSource } from ".";
+import { DataSource, Source } from ".";
 import { LiteREST } from "./literest";
 import { executeQuery, executeTransaction } from "./operation";
 import { createResponse, QueryRequest, QueryTransactionRequest } from "./utils";
 import { Env } from './'
 import { handleApiRequest } from "./api";
+import { dumpDatabaseRoute } from "./export/dump";
+import { exportTableToJsonRoute } from "./export/json";
+import { exportTableToCsvRoute } from "./export/csv";
+import { importDumpRoute } from "./import/dump";
+import { importTableFromJsonRoute } from "./import/json";
+import { importTableFromCsvRoute } from "./import/csv";
 
 export class Handler {
     private liteREST?: LiteREST;
@@ -24,35 +30,58 @@ export class Handler {
             return this.clientConnected();
         } else if (url.pathname.startsWith('/rest')) {
             return await this.liteREST.handleRequest(request);
-        
-        // else if (request.method === 'GET' && url.pathname === '/export/dump') {
-        //     return dumpDatabaseRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation);
-        // } else if (request.method === 'GET' && url.pathname.startsWith('/export/json/')) {
-        //     const tableName = url.pathname.split('/').pop();
-        //     if (!tableName) {
-        //         return createResponse(undefined, 'Table name is required', 400);
-        //     }
-        //     return exportTableToJsonRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName);
-        // } else if (request.method === 'GET' && url.pathname.startsWith('/export/csv/')) {
-        //     const tableName = url.pathname.split('/').pop();
-        //     if (!tableName) {
-        //         return createResponse(undefined, 'Table name is required', 400);
-        //     }
-        //     return exportTableToCsvRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName);
-        // } else if (request.method === 'POST' && url.pathname === '/import/dump') {
-        //     return importDumpRoute(request, this.sql, this.operationQueue, this.ctx, this.processingOperation);
-        // } else if (request.method === 'POST' && url.pathname.startsWith('/import/json/')) {
-        //     const tableName = url.pathname.split('/').pop();
-        //     if (!tableName) {
-        //         return createResponse(undefined, 'Table name is required', 400);
-        //     }
-        //     return importTableFromJsonRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName, request);
-        // } else if (request.method === 'POST' && url.pathname.startsWith('/import/csv/')) {
-        //     const tableName = url.pathname.split('/').pop();
-        //     if (!tableName) {
-        //         return createResponse(undefined, 'Table name is required', 400);
-        //     }
-        //     return importTableFromCsvRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName, request);
+        } else if (request.method === 'GET' && url.pathname === '/export/dump') {
+            if (this.dataSource.source === Source.external) {
+                return createResponse(undefined, 'Function is only available for internal data source.', 400);
+            }
+
+            return dumpDatabaseRoute(this.dataSource);
+        } else if (request.method === 'GET' && url.pathname.startsWith('/export/json/')) {
+            if (this.dataSource.source === Source.external) {
+                return createResponse(undefined, 'Function is only available for internal data source.', 400);
+            }
+
+            const tableName = url.pathname.split('/').pop();
+            if (!tableName) {
+                return createResponse(undefined, 'Table name is required', 400);
+            }
+            return exportTableToJsonRoute(tableName, this.dataSource);
+        } else if (request.method === 'GET' && url.pathname.startsWith('/export/csv/')) {
+            if (this.dataSource.source === Source.external) {
+                return createResponse(undefined, 'Function is only available for internal data source.', 400);
+            }
+
+            const tableName = url.pathname.split('/').pop();
+            if (!tableName) {
+                return createResponse(undefined, 'Table name is required', 400);
+            }
+            return exportTableToCsvRoute(tableName, this.dataSource);
+        } else if (request.method === 'POST' && url.pathname === '/import/dump') {
+            if (this.dataSource.source === Source.external) {
+                return createResponse(undefined, 'Function is only available for internal data source.', 400);
+            }
+
+            return importDumpRoute(request, this.dataSource);
+        } else if (request.method === 'POST' && url.pathname.startsWith('/import/json/')) {
+            if (this.dataSource.source === Source.external) {
+                return createResponse(undefined, 'Function is only available for internal data source.', 400);
+            }
+
+            const tableName = url.pathname.split('/').pop();
+            if (!tableName) {
+                return createResponse(undefined, 'Table name is required', 400);
+            }
+            return importTableFromJsonRoute(tableName, request, this.dataSource);
+        } else if (request.method === 'POST' && url.pathname.startsWith('/import/csv/')) {
+            if (this.dataSource.source === Source.external) {
+                return createResponse(undefined, 'Function is only available for internal data source.', 400);
+            }
+            
+            const tableName = url.pathname.split('/').pop();
+            if (!tableName) {
+                return createResponse(undefined, 'Table name is required', 400);
+            }
+            return importTableFromCsvRoute(tableName, request, this.dataSource);
         } else if (url.pathname.startsWith('/api')) {
             return await handleApiRequest(request);
         }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -7,7 +7,7 @@ import { importTableFromCsvRoute } from "./import/csv";
 import { importDumpRoute } from "./import/dump";
 import { importTableFromJsonRoute } from "./import/json";
 import { LiteREST } from "./literest";
-import { executeQuery, OperationQueueItem } from "./operation";
+import { executeQuery, executeTransaction, OperationQueueItem } from "./operation";
 import { createResponse, createResponseFromOperationResponse, QueryRequest, QueryTransactionRequest } from "./utils";
 
 export class Handler {
@@ -88,9 +88,6 @@ export class Handler {
     }
 
     async queryRoute(request: Request, isRaw: boolean): Promise<Response> {
-        // TODO:
-        // Is it for the `internal` or `external` source?
-
         if (!this.dataSource) {
             return createResponse(undefined, 'Data source not found.', 400);
         }
@@ -122,6 +119,9 @@ export class Handler {
 
                     return { sql, params };
                 });
+
+                const response = await executeTransaction(queries, isRaw, this.dataSource);
+                return createResponse(response, undefined, 200);
 
                 // try {
                 //     const response = await enqueueOperation(

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,58 +1,31 @@
-import { DataSource, Source } from ".";
-import { handleApiRequest } from "./api";
-import { exportTableToCsvRoute } from "./export/csv";
-import { dumpDatabaseRoute } from "./export/dump";
-import { exportTableToJsonRoute } from "./export/json";
-import { importTableFromCsvRoute } from "./import/csv";
-import { importDumpRoute } from "./import/dump";
-import { importTableFromJsonRoute } from "./import/json";
+import { DataSource } from ".";
 import { LiteREST } from "./literest";
-import { executeQuery, executeTransaction, OperationQueueItem } from "./operation";
-import { createResponse, createResponseFromOperationResponse, QueryRequest, QueryTransactionRequest } from "./utils";
+import { executeQuery, executeTransaction } from "./operation";
+import { createResponse, QueryRequest, QueryTransactionRequest } from "./utils";
+import { Env } from './'
+import { handleApiRequest } from "./api";
 
 export class Handler {
-    // Queue of operations to be processed, with each operation containing a list of queries to be executed
-    private operationQueue: Array<OperationQueueItem> = [];
-
-    // Flag to indicate if an operation is currently being processed
-    private processingOperation: { value: boolean } = { value: false };
-
-    // Map of WebSocket connections to their corresponding session IDs
-    private connections = new Map<string, WebSocket>();
-
-    // Instantiate LiteREST
     private liteREST?: LiteREST;
-
     private dataSource?: DataSource;
 
-    // You can inject dependencies via the constructor if needed
-    constructor(/* dependencies */) {
-        // Initialize LiteREST for handling /lite routes
-        // this.liteREST = new LiteREST(
-        //     ctx,
-        //     this.operationQueue,
-        //     this.processingOperation,
-        //     this.sql
-        // );
-    }
+    constructor() { }
 
-    // Main method to handle the request
-    public async handle(request: Request, dataSource: DataSource): Promise<Response> {
+    public async handle(request: Request, dataSource: DataSource, env: Env): Promise<Response> {
         this.dataSource = dataSource;
+        this.liteREST = new LiteREST(dataSource, env);
         const url = new URL(request.url);
-
-        // return createResponse(dataSource, undefined, 200);
 
         if (request.method === 'POST' && url.pathname === '/query/raw') {
             return this.queryRoute(request, true);
         } else if (request.method === 'POST' && url.pathname === '/query') {
             return this.queryRoute(request, false);
-        } 
-        // else if (url.pathname === '/socket') {
-        //     return this.clientConnected();
-        // } else if (url.pathname.startsWith('/rest')) {
-        //     return await this.liteREST.handleRequest(request);
-        // } else if (request.method === 'GET' && url.pathname === '/export/dump') {
+        } else if (url.pathname === '/socket') {
+            return this.clientConnected();
+        } else if (url.pathname.startsWith('/rest')) {
+            return await this.liteREST.handleRequest(request);
+        
+        // else if (request.method === 'GET' && url.pathname === '/export/dump') {
         //     return dumpDatabaseRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation);
         // } else if (request.method === 'GET' && url.pathname.startsWith('/export/json/')) {
         //     const tableName = url.pathname.split('/').pop();
@@ -80,18 +53,14 @@ export class Handler {
         //         return createResponse(undefined, 'Table name is required', 400);
         //     }
         //     return importTableFromCsvRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName, request);
-        // } else if (url.pathname.startsWith('/api')) {
-        //     return await handleApiRequest(request);
-        // }
+        } else if (url.pathname.startsWith('/api')) {
+            return await handleApiRequest(request);
+        }
 
         return createResponse(undefined, 'Unknown operation', 400);
     }
 
     async queryRoute(request: Request, isRaw: boolean): Promise<Response> {
-        if (!this.dataSource) {
-            return createResponse(undefined, 'Data source not found.', 400);
-        }
-
         try {
             const contentType = request.headers.get('Content-Type') || '';
             if (!contentType.includes('application/json')) {
@@ -100,21 +69,14 @@ export class Handler {
     
             const { sql, params, transaction } = await request.json() as QueryRequest & QueryTransactionRequest;
 
-            // const response = await executeQuery(sql, params, isRaw, this.dataSource);
-            // return createResponse(response, undefined, 200);
-    
-
-
-
-
             if (Array.isArray(transaction) && transaction.length) {
                 const queries = transaction.map((queryObj: any) => {
                     const { sql, params } = queryObj;
 
                     if (typeof sql !== 'string' || !sql.trim()) {
                         throw new Error('Invalid or empty "sql" field in transaction.');
-                    } else if (params !== undefined && !Array.isArray(params)) {
-                        throw new Error('Invalid "params" field in transaction.');
+                    } else if (params !== undefined && !Array.isArray(params) && typeof params !== 'object') {
+                        throw new Error('Invalid "params" field in transaction. Must be an array or object.');
                     }
 
                     return { sql, params };
@@ -122,86 +84,37 @@ export class Handler {
 
                 const response = await executeTransaction(queries, isRaw, this.dataSource);
                 return createResponse(response, undefined, 200);
-
-                // try {
-                //     const response = await enqueueOperation(
-                //         queries,
-                //         true,
-                //         isRaw,
-                //         this.operationQueue,
-                //         () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-                //     );
-
-                //     return createResponseFromOperationResponse(response);
-                // } catch (error: any) {
-                //     return createResponse(undefined, error.error || 'An unexpected error occurred.', error.status || 500);
-                // }
             } else if (typeof sql !== 'string' || !sql.trim()) {
                 return createResponse(undefined, 'Invalid or empty "sql" field.', 400);
-            } else if (params !== undefined && !Array.isArray(params)) {
-                return createResponse(undefined, 'Invalid "params" field.', 400);
+            } else if (params !== undefined && !Array.isArray(params) && typeof params !== 'object') {
+                return createResponse(undefined, 'Invalid "params" field. Must be an array or object.', 400);
             }
 
             const response = await executeQuery(sql, params, isRaw, this.dataSource);
             return createResponse(response, undefined, 200);
-
-            // try {
-            //     const queries = [{ sql, params }];
-            //     const response = await enqueueOperation(
-            //         queries,
-            //         false,
-            //         isRaw,
-            //         this.operationQueue,
-            //         () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-            //     );
-                
-            //     return createResponseFromOperationResponse(response);
-            // } catch (error: any) {
-            //     return createResponse(undefined, error.error || 'An unexpected error occurred.', error.status || 500);
-            // }
         } catch (error: any) {
             console.error('Query Route Error:', error);
             return createResponse(undefined, error || 'An unexpected error occurred.', 500);
         }
     }
 
-    // clientConnected() {
-    //     const webSocketPair = new WebSocketPair();
-    //     const [client, server] = Object.values(webSocketPair);
-    //     const wsSessionId = crypto.randomUUID();
+    clientConnected() {
+        const webSocketPair = new WebSocketPair();
+        const [client, server] = Object.values(webSocketPair);
 
-    //     this.ctx.acceptWebSocket(server, [wsSessionId]);
-    //     this.connections.set(wsSessionId, client);
+        server.accept();
+        server.addEventListener('message', event => {
+            const { sql, params, action } = JSON.parse(event.data as string);
 
-    //     return new Response(null, { status: 101, webSocket: client });
-    // }
+            if (action === 'query') {
+                const executeQueryWrapper = async () => {
+                    const response = await executeQuery(sql, params, false, this.dataSource);
+                    server.send(JSON.stringify(response));
+                };
+                executeQueryWrapper();
+            }
+        });
 
-    // async webSocketMessage(ws: WebSocket, message: any) {
-    //     const { sql, params, action } = JSON.parse(message);
-    
-    //     if (action === 'query') {
-    //         const queries = [{ sql, params }];
-    //         const response = await enqueueOperation(
-    //             queries,
-    //             false,
-    //             false,
-    //             this.operationQueue,
-    //             () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-    //         );
-
-    //         ws.send(JSON.stringify(response.result));
-    //     }
-    // }
-
-    // async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
-    //     // If the client closes the connection, the runtime will invoke the webSocketClose() handler.
-    //     ws.close(code, "StarbaseDB is closing WebSocket connection");
-
-    //     // Remove the WebSocket connection from the map
-    //     const tags = this.ctx.getTags(ws);
-    //     if (tags.length) {
-    //         const wsSessionId = tags[0];
-    //         this.connections.delete(wsSessionId);
-    //     }
-    // }
+        return new Response(null, { status: 101, webSocket: client });
+    }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,0 +1,207 @@
+import { DataSource, Source } from ".";
+import { handleApiRequest } from "./api";
+import { exportTableToCsvRoute } from "./export/csv";
+import { dumpDatabaseRoute } from "./export/dump";
+import { exportTableToJsonRoute } from "./export/json";
+import { importTableFromCsvRoute } from "./import/csv";
+import { importDumpRoute } from "./import/dump";
+import { importTableFromJsonRoute } from "./import/json";
+import { LiteREST } from "./literest";
+import { executeQuery, OperationQueueItem } from "./operation";
+import { createResponse, createResponseFromOperationResponse, QueryRequest, QueryTransactionRequest } from "./utils";
+
+export class Handler {
+    // Queue of operations to be processed, with each operation containing a list of queries to be executed
+    private operationQueue: Array<OperationQueueItem> = [];
+
+    // Flag to indicate if an operation is currently being processed
+    private processingOperation: { value: boolean } = { value: false };
+
+    // Map of WebSocket connections to their corresponding session IDs
+    private connections = new Map<string, WebSocket>();
+
+    // Instantiate LiteREST
+    private liteREST?: LiteREST;
+
+    private dataSource?: DataSource;
+
+    // You can inject dependencies via the constructor if needed
+    constructor(/* dependencies */) {
+        // Initialize LiteREST for handling /lite routes
+        // this.liteREST = new LiteREST(
+        //     ctx,
+        //     this.operationQueue,
+        //     this.processingOperation,
+        //     this.sql
+        // );
+    }
+
+    // Main method to handle the request
+    public async handle(request: Request, dataSource: DataSource): Promise<Response> {
+        this.dataSource = dataSource;
+        const url = new URL(request.url);
+
+        // return createResponse(dataSource, undefined, 200);
+
+        if (request.method === 'POST' && url.pathname === '/query/raw') {
+            return this.queryRoute(request, true);
+        } else if (request.method === 'POST' && url.pathname === '/query') {
+            return this.queryRoute(request, false);
+        } 
+        // else if (url.pathname === '/socket') {
+        //     return this.clientConnected();
+        // } else if (url.pathname.startsWith('/rest')) {
+        //     return await this.liteREST.handleRequest(request);
+        // } else if (request.method === 'GET' && url.pathname === '/export/dump') {
+        //     return dumpDatabaseRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation);
+        // } else if (request.method === 'GET' && url.pathname.startsWith('/export/json/')) {
+        //     const tableName = url.pathname.split('/').pop();
+        //     if (!tableName) {
+        //         return createResponse(undefined, 'Table name is required', 400);
+        //     }
+        //     return exportTableToJsonRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName);
+        // } else if (request.method === 'GET' && url.pathname.startsWith('/export/csv/')) {
+        //     const tableName = url.pathname.split('/').pop();
+        //     if (!tableName) {
+        //         return createResponse(undefined, 'Table name is required', 400);
+        //     }
+        //     return exportTableToCsvRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName);
+        // } else if (request.method === 'POST' && url.pathname === '/import/dump') {
+        //     return importDumpRoute(request, this.sql, this.operationQueue, this.ctx, this.processingOperation);
+        // } else if (request.method === 'POST' && url.pathname.startsWith('/import/json/')) {
+        //     const tableName = url.pathname.split('/').pop();
+        //     if (!tableName) {
+        //         return createResponse(undefined, 'Table name is required', 400);
+        //     }
+        //     return importTableFromJsonRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName, request);
+        // } else if (request.method === 'POST' && url.pathname.startsWith('/import/csv/')) {
+        //     const tableName = url.pathname.split('/').pop();
+        //     if (!tableName) {
+        //         return createResponse(undefined, 'Table name is required', 400);
+        //     }
+        //     return importTableFromCsvRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName, request);
+        // } else if (url.pathname.startsWith('/api')) {
+        //     return await handleApiRequest(request);
+        // }
+
+        return createResponse(undefined, 'Unknown operation', 400);
+    }
+
+    async queryRoute(request: Request, isRaw: boolean): Promise<Response> {
+        // TODO:
+        // Is it for the `internal` or `external` source?
+
+        if (!this.dataSource) {
+            return createResponse(undefined, 'Data source not found.', 400);
+        }
+
+        try {
+            const contentType = request.headers.get('Content-Type') || '';
+            if (!contentType.includes('application/json')) {
+                return createResponse(undefined, 'Content-Type must be application/json.', 400);
+            }
+    
+            const { sql, params, transaction } = await request.json() as QueryRequest & QueryTransactionRequest;
+
+            // const response = await executeQuery(sql, params, isRaw, this.dataSource);
+            // return createResponse(response, undefined, 200);
+    
+
+
+
+
+            if (Array.isArray(transaction) && transaction.length) {
+                const queries = transaction.map((queryObj: any) => {
+                    const { sql, params } = queryObj;
+
+                    if (typeof sql !== 'string' || !sql.trim()) {
+                        throw new Error('Invalid or empty "sql" field in transaction.');
+                    } else if (params !== undefined && !Array.isArray(params)) {
+                        throw new Error('Invalid "params" field in transaction.');
+                    }
+
+                    return { sql, params };
+                });
+
+                // try {
+                //     const response = await enqueueOperation(
+                //         queries,
+                //         true,
+                //         isRaw,
+                //         this.operationQueue,
+                //         () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+                //     );
+
+                //     return createResponseFromOperationResponse(response);
+                // } catch (error: any) {
+                //     return createResponse(undefined, error.error || 'An unexpected error occurred.', error.status || 500);
+                // }
+            } else if (typeof sql !== 'string' || !sql.trim()) {
+                return createResponse(undefined, 'Invalid or empty "sql" field.', 400);
+            } else if (params !== undefined && !Array.isArray(params)) {
+                return createResponse(undefined, 'Invalid "params" field.', 400);
+            }
+
+            const response = await executeQuery(sql, params, isRaw, this.dataSource);
+            return createResponse(response, undefined, 200);
+
+            // try {
+            //     const queries = [{ sql, params }];
+            //     const response = await enqueueOperation(
+            //         queries,
+            //         false,
+            //         isRaw,
+            //         this.operationQueue,
+            //         () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+            //     );
+                
+            //     return createResponseFromOperationResponse(response);
+            // } catch (error: any) {
+            //     return createResponse(undefined, error.error || 'An unexpected error occurred.', error.status || 500);
+            // }
+        } catch (error: any) {
+            console.error('Query Route Error:', error);
+            return createResponse(undefined, error || 'An unexpected error occurred.', 500);
+        }
+    }
+
+    // clientConnected() {
+    //     const webSocketPair = new WebSocketPair();
+    //     const [client, server] = Object.values(webSocketPair);
+    //     const wsSessionId = crypto.randomUUID();
+
+    //     this.ctx.acceptWebSocket(server, [wsSessionId]);
+    //     this.connections.set(wsSessionId, client);
+
+    //     return new Response(null, { status: 101, webSocket: client });
+    // }
+
+    // async webSocketMessage(ws: WebSocket, message: any) {
+    //     const { sql, params, action } = JSON.parse(message);
+    
+    //     if (action === 'query') {
+    //         const queries = [{ sql, params }];
+    //         const response = await enqueueOperation(
+    //             queries,
+    //             false,
+    //             false,
+    //             this.operationQueue,
+    //             () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
+    //         );
+
+    //         ws.send(JSON.stringify(response.result));
+    //     }
+    // }
+
+    // async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
+    //     // If the client closes the connection, the runtime will invoke the webSocketClose() handler.
+    //     ws.close(code, "StarbaseDB is closing WebSocket connection");
+
+    //     // Remove the WebSocket connection from the map
+    //     const tags = this.ctx.getTags(ws);
+    //     if (tags.length) {
+    //         const wsSessionId = tags[0];
+    //         this.connections.delete(wsSessionId);
+    //     }
+    // }
+}

--- a/src/import/csv.ts
+++ b/src/import/csv.ts
@@ -1,5 +1,6 @@
 import { createResponse } from '../utils';
-import { enqueueOperation, processNextOperation } from '../operation';
+import { DataSource } from '..';
+import { executeOperation } from '../export';
 
 interface ColumnMapping {
     [key: string]: string;
@@ -11,12 +12,9 @@ interface CsvData {
 }
 
 export async function importTableFromCsvRoute(
-    sql: SqlStorage,
-    operationQueue: any,
-    ctx: any,
-    processingOperation: { value: boolean },
     tableName: string,
-    request: Request
+    request: Request,
+    dataSource: DataSource
 ): Promise<Response> {
     try {
         if (!request.body) {
@@ -69,13 +67,7 @@ export async function importTableFromCsvRoute(
             const statement = `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
 
             try {
-                await enqueueOperation(
-                    [{ sql: statement, params: values }],
-                    false,
-                    false,
-                    operationQueue,
-                    () => processNextOperation(sql, operationQueue, ctx, processingOperation)
-                );
+                await executeOperation([{ sql: statement, params: values }], dataSource)
                 successCount++;
             } catch (error: any) {
                 failedStatements.push({

--- a/src/import/dump.ts
+++ b/src/import/dump.ts
@@ -1,5 +1,6 @@
 import { createResponse } from '../utils';
-import { OperationQueueItem } from '../operation';
+import { DataSource } from '..';
+import { executeOperation } from '../export';
 
 function parseSqlStatements(sqlContent: string): string[] {
     const lines = sqlContent.split('\n');
@@ -30,10 +31,7 @@ function parseSqlStatements(sqlContent: string): string[] {
 
 export async function importDumpRoute(
     request: Request,
-    sql: SqlStorage,
-    operationQueue: Array<OperationQueueItem>,
-    ctx: DurableObjectState,
-    processingOperation: { value: boolean }
+    dataSource: DataSource
 ): Promise<Response> {
     if (request.method !== 'POST') {
         return createResponse(undefined, 'Method not allowed', 405);
@@ -68,7 +66,7 @@ export async function importDumpRoute(
         const results = [];
         for (const statement of sqlStatements) {
             try {
-                const result = await sql.exec(statement);
+                const result = await executeOperation([{ sql: statement }], dataSource)
                 results.push({ statement, success: true, result });
             } catch (error: any) {
                 console.error(`Error executing statement: ${statement}`, error);

--- a/src/import/json.ts
+++ b/src/import/json.ts
@@ -1,5 +1,6 @@
 import { createResponse } from '../utils';
-import { enqueueOperation, processNextOperation } from '../operation';
+import { executeOperation } from '../export';
+import { DataSource } from '..';
 
 interface ColumnMapping {
     [key: string]: string;
@@ -11,12 +12,9 @@ interface JsonData {
 }
 
 export async function importTableFromJsonRoute(
-    sql: SqlStorage,
-    operationQueue: any,
-    ctx: any,
-    processingOperation: { value: boolean },
     tableName: string,
-    request: Request
+    request: Request,
+    dataSource: DataSource
 ): Promise<Response> {
     try {
         if (!request.body) {
@@ -62,13 +60,7 @@ export async function importTableFromJsonRoute(
             const statement = `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
 
             try {
-                await enqueueOperation(
-                    [{ sql: statement, params: values }],
-                    false,
-                    false,
-                    operationQueue,
-                    () => processNextOperation(sql, operationQueue, ctx, processingOperation)
-                );
+                await executeOperation([{ sql: statement, params: values }], dataSource)
                 successCount++;
             } catch (error: any) {
                 failedStatements.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ export default {
             },
             externalConnection: {
                 outerbaseApiKey: env.OUTERBASE_API_KEY ?? ''
-            },
+            }
         };
 
         const response = await new Handler().handle(request, dataSource, env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,7 @@ export interface Env {
   
     // External database source details
     EXTERNAL_DB_TYPE?: string;
-    EXTERNAL_DB_HOST?: string;
-    EXTERNAL_DB_NAME?: string;
-    EXTERNAL_DB_USER?: string;
-    EXTERNAL_DB_PASS?: string;
-    EXTERNAL_DB_PORT?: string;
+    OUTERBASE_API_KEY?: string;
   
     // ## DO NOT REMOVE: TEMPLATE INTERFACE ##
 }
@@ -49,6 +45,19 @@ type DatabaseStub = DurableObjectStub & {
     executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse;
     executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean): any[];
 };
+
+enum RegionLocationHint {
+    AUTO = 'auto',
+    WNAM = 'wnam', // Western North America
+    ENAM = 'enam', // Eastern North America
+    SAM = 'sam', // South America
+    WEUR = 'weur', // Western Europe
+    EEUR = 'eeur', // Eastern Europe
+    APAC = 'apac', // Asia Pacific
+    OC = 'oc', // Oceania
+    AFR = 'afr', // Africa
+    ME = 'me', // Middle East
+}
 
 export default {
 	/**
@@ -113,8 +122,7 @@ export default {
                 durableObject: stub as unknown as DatabaseStub,
             },
             externalConnection: {
-                // TODO: Should the API key instead live in the `wrangler.toml` file instead of request headers?
-                outerbaseApiKey: request.headers.get('X-Outerbase-Source-Token') ?? url.searchParams.get('outerbaseApiKey') ?? '',
+                outerbaseApiKey: env.OUTERBASE_API_KEY ?? ''
             },
         };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
 import { createResponse, createResponseFromOperationResponse, QueryRequest, QueryTransactionRequest } from './utils';
-import { enqueueOperation, OperationQueueItem, processNextOperation } from './operation';
 import { LiteREST } from './literest';
 import handleStudioRequest from "./studio";
 import { dumpDatabaseRoute } from './export/dump';
@@ -10,6 +9,9 @@ import { importDumpRoute } from './import/dump';
 import { importTableFromJsonRoute } from './import/json';
 import { importTableFromCsvRoute } from './import/csv';
 import { handleApiRequest } from "./api";
+import { Handler } from "./handler";
+import { QueryResponse } from "./operation";
+export { DatabaseDurableObject } from './do'; 
 
 const DURABLE_OBJECT_ID = 'sql-durable-object';
 
@@ -21,226 +23,28 @@ interface Env {
     // ## DO NOT REMOVE: TEMPLATE INTERFACE ##
 }
 
-export class DatabaseDurableObject extends DurableObject {
-    // Durable storage for the SQL database
-    public sql: SqlStorage;
+export enum Source {
+    internal = 'internal',  // Durable Object's SQLite instance
+    external = 'external'   // External data source (e.g. Outerbase)
+}
 
-    // Queue of operations to be processed, with each operation containing a list of queries to be executed
-    private operationQueue: Array<OperationQueueItem> = [];
+export type DataSource = {
+    source: Source;
+    request: Request;
+    internalConnection?: InternalConnection;
+    externalConnection?: {
+        // API Key for Outerbase which currently controls querying external data sources
+        outerbaseApiKey: string;
+    };
+}
 
-    // Flag to indicate if an operation is currently being processed
-    private processingOperation: { value: boolean } = { value: false };
+type DatabaseStub = DurableObjectStub & {
+    fetch: (init?: RequestInit | Request) => Promise<Response>;
+    executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse;
+};
 
-    // Map of WebSocket connections to their corresponding session IDs
-    private connections = new Map<string, WebSocket>();
-
-    // Instantiate LiteREST
-    private liteREST: LiteREST;
-
-	/**
-	 * The constructor is invoked once upon creation of the Durable Object, i.e. the first call to
-	 * 	`DurableObjectStub::get` for a given identifier (no-op constructors can be omitted)
-	 *
-	 * @param ctx - The interface for interacting with Durable Object state
-	 * @param env - The interface to reference bindings declared in wrangler.toml
-	 */
-    constructor(ctx: DurableObjectState, env: Env) {
-        super(ctx, env);
-        this.sql = ctx.storage.sql;
-
-        // Initialize LiteREST for handling /lite routes
-        this.liteREST = new LiteREST(
-            ctx,
-            this.operationQueue,
-            this.processingOperation,
-            this.sql
-        );
-    }
-
-    /**
-     * Execute a raw SQL query on the database, typically used for external requests
-     * from other service bindings (e.g. auth). This serves as an exposed function for
-     * other service bindings to query the database without having to have knowledge of
-     * the current operation queue or processing state.
-     * 
-     * @param sql - The SQL query to execute.
-     * @param params - Optional parameters for the SQL query.
-     * @returns A response containing the query result or an error message.
-     */
-    async executeExternalQuery(sql: string, params: any[] | undefined): Promise<any> {
-        try {
-            const queries = [{ sql, params }];
-            const response = await enqueueOperation(
-                queries,
-                false,
-                false,
-                this.operationQueue,
-                () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-            );
-
-            return response;
-        } catch (error: any) {
-            console.error('Execute External Query Error:', error);
-            return null;
-        }
-    }
-
-    async queryRoute(request: Request, isRaw: boolean): Promise<Response> {
-        try {
-            const contentType = request.headers.get('Content-Type') || '';
-            if (!contentType.includes('application/json')) {
-                return createResponse(undefined, 'Content-Type must be application/json.', 400);
-            }
-    
-            const { sql, params, transaction } = await request.json() as QueryRequest & QueryTransactionRequest;
-    
-            if (Array.isArray(transaction) && transaction.length) {
-                const queries = transaction.map((queryObj: any) => {
-                    const { sql, params } = queryObj;
-
-                    if (typeof sql !== 'string' || !sql.trim()) {
-                        throw new Error('Invalid or empty "sql" field in transaction.');
-                    } else if (params !== undefined && !Array.isArray(params)) {
-                        throw new Error('Invalid "params" field in transaction.');
-                    }
-
-                    return { sql, params };
-                });
-
-                try {
-                    const response = await enqueueOperation(
-                        queries,
-                        true,
-                        isRaw,
-                        this.operationQueue,
-                        () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-                    );
-
-                    return createResponseFromOperationResponse(response);
-                } catch (error: any) {
-                    return createResponse(undefined, error.error || 'An unexpected error occurred.', error.status || 500);
-                }
-            } else if (typeof sql !== 'string' || !sql.trim()) {
-                return createResponse(undefined, 'Invalid or empty "sql" field.', 400);
-            } else if (params !== undefined && !Array.isArray(params)) {
-                return createResponse(undefined, 'Invalid "params" field.', 400);
-            }
-
-            try {
-                const queries = [{ sql, params }];
-                const response = await enqueueOperation(
-                    queries,
-                    false,
-                    isRaw,
-                    this.operationQueue,
-                    () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-                );
-                
-                return createResponseFromOperationResponse(response);
-            } catch (error: any) {
-                return createResponse(undefined, error.error || 'An unexpected error occurred.', error.status || 500);
-            }
-        } catch (error: any) {
-            console.error('Query Route Error:', error);
-            return createResponse(undefined, error || 'An unexpected error occurred.', 500);
-        }
-    }
-
-    async statusRoute(_: Request): Promise<Response> {
-        return createResponse({ 
-            status: 'reachable',
-            timestamp: Date.now(),
-            usedDisk: await this.sql.databaseSize,
-        }, undefined, 200)
-    }
-
-    async fetch(request: Request): Promise<Response> {
-        const url = new URL(request.url);
-
-        if (request.method === 'POST' && url.pathname === '/query/raw') {
-            return this.queryRoute(request, true);
-        } else if (request.method === 'POST' && url.pathname === '/query') {
-            return this.queryRoute(request, false);
-        } else if (url.pathname === '/socket') {
-            return this.clientConnected();
-        } else if (request.method === 'GET' && url.pathname === '/status') {
-            return this.statusRoute(request);
-        } else if (url.pathname.startsWith('/rest')) {
-            return await this.liteREST.handleRequest(request);
-        } else if (request.method === 'GET' && url.pathname === '/export/dump') {
-            return dumpDatabaseRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation);
-        } else if (request.method === 'GET' && url.pathname.startsWith('/export/json/')) {
-            const tableName = url.pathname.split('/').pop();
-            if (!tableName) {
-                return createResponse(undefined, 'Table name is required', 400);
-            }
-            return exportTableToJsonRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName);
-        } else if (request.method === 'GET' && url.pathname.startsWith('/export/csv/')) {
-            const tableName = url.pathname.split('/').pop();
-            if (!tableName) {
-                return createResponse(undefined, 'Table name is required', 400);
-            }
-            return exportTableToCsvRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName);
-        } else if (request.method === 'POST' && url.pathname === '/import/dump') {
-            return importDumpRoute(request, this.sql, this.operationQueue, this.ctx, this.processingOperation);
-        } else if (request.method === 'POST' && url.pathname.startsWith('/import/json/')) {
-            const tableName = url.pathname.split('/').pop();
-            if (!tableName) {
-                return createResponse(undefined, 'Table name is required', 400);
-            }
-            return importTableFromJsonRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName, request);
-        } else if (request.method === 'POST' && url.pathname.startsWith('/import/csv/')) {
-            const tableName = url.pathname.split('/').pop();
-            if (!tableName) {
-                return createResponse(undefined, 'Table name is required', 400);
-            }
-            return importTableFromCsvRoute(this.sql, this.operationQueue, this.ctx, this.processingOperation, tableName, request);
-        } else if (url.pathname.startsWith('/api')) {
-            return await handleApiRequest(request);
-        } else {
-            return createResponse(undefined, 'Unknown operation', 400);
-        }
-    }
-
-    clientConnected() {
-        const webSocketPair = new WebSocketPair();
-        const [client, server] = Object.values(webSocketPair);
-        const wsSessionId = crypto.randomUUID();
-
-        this.ctx.acceptWebSocket(server, [wsSessionId]);
-        this.connections.set(wsSessionId, client);
-
-        return new Response(null, { status: 101, webSocket: client });
-    }
-
-    async webSocketMessage(ws: WebSocket, message: any) {
-        const { sql, params, action } = JSON.parse(message);
-    
-        if (action === 'query') {
-            const queries = [{ sql, params }];
-            const response = await enqueueOperation(
-                queries,
-                false,
-                false,
-                this.operationQueue,
-                () => processNextOperation(this.sql, this.operationQueue, this.ctx, this.processingOperation)
-            );
-
-            ws.send(JSON.stringify(response.result));
-        }
-    }
-
-    async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
-        // If the client closes the connection, the runtime will invoke the webSocketClose() handler.
-        ws.close(code, "StarbaseDB is closing WebSocket connection");
-
-        // Remove the WebSocket connection from the map
-        const tags = this.ctx.getTags(ws);
-        if (tags.length) {
-            const wsSessionId = tags[0];
-            this.connections.delete(wsSessionId);
-        }
-    }
+interface InternalConnection {
+    durableObject: DatabaseStub;
 }
 
 export default {
@@ -297,12 +101,22 @@ export default {
         let id: DurableObjectId = env.DATABASE_DURABLE_OBJECT.idFromName(DURABLE_OBJECT_ID);
 		let stub = env.DATABASE_DURABLE_OBJECT.get(id);
 
+        const source: Source = request.headers.get('X-Starbase-Source') as Source ?? 'internal';
+        const dataSource: DataSource = {
+            source: source,
+            request: request.clone(),
+            internalConnection: {
+                durableObject: stub as unknown as DatabaseStub,
+            },
+            externalConnection: {
+                outerbaseApiKey: request.headers.get('X-Outerbase-Source-Token') ?? '',
+            },
+        };
+
+        const response = await new Handler().handle(request, dataSource);
+
         // ## DO NOT REMOVE: TEMPLATE ROUTING ##
 
-        /**
-         * Pass the fetch request directly to the Durable Object, which will handle the request
-         * and return a response to be sent back to the client.
-         */
-        return await stub.fetch(request);
+        return response;
 	},
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export type DataSource = {
 type DatabaseStub = DurableObjectStub & {
     fetch: (init?: RequestInit | Request) => Promise<Response>;
     executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse;
+    executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean): any[];
 };
 
 interface InternalConnection {
@@ -98,6 +99,9 @@ export default {
          * Retrieve the Durable Object identifier from the environment bindings and instantiate a
          * Durable Object stub to interact with the Durable Object.
          */
+        // Get location hint from wrangler.toml environment variables
+        // const locationHint = env.DATABASE_LOCATION_HINT ?? 'enam';
+        // let stub = env.DATABASE_DURABLE_OBJECT.get(id, { locationHint: "enam" });
         let id: DurableObjectId = env.DATABASE_DURABLE_OBJECT.idFromName(DURABLE_OBJECT_ID);
 		let stub = env.DATABASE_DURABLE_OBJECT.get(id);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export default {
                 durableObject: stub as unknown as DatabaseStub,
             },
             externalConnection: {
+                // TODO: Should the API key instead live in the `wrangler.toml` file instead of request headers?
                 outerbaseApiKey: request.headers.get('X-Outerbase-Source-Token') ?? url.searchParams.get('outerbaseApiKey') ?? '',
             },
         };

--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -55,9 +55,7 @@ export class LiteREST {
         }
 
         const schemaInfo = (await executeQuery(query, this.dataSource.source === Source.external ? {} : [], false, this.dataSource, this.env)) as any[];
-        const pkColumns = schemaInfo
-            // .filter(col => typeof col.pk === 'number' && col.pk > 0 && col.name !== null)
-            .map(col => col.name as string);
+        const pkColumns = schemaInfo.map(col => col.name as string);
         return pkColumns;
     }
 
@@ -290,7 +288,7 @@ export class LiteREST {
         // Sanitize column names
         const columns = dataKeys.map(col => this.sanitizeIdentifier(col));
         const placeholders = columns.map(() => '?').join(', ');
-        const query = `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
+        const query = `INSERT INTO ${schemaName ? `${schemaName}.` : ''}${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
 
         // Map parameters using original data keys to get correct values
         const params = dataKeys.map(key => data[key]);
@@ -338,7 +336,7 @@ export class LiteREST {
         // Sanitize column names
         const columns = updateKeys.map(col => this.sanitizeIdentifier(col));
         const setClause = columns.map(col => `${col} = ?`).join(', ');
-        const query = `UPDATE ${tableName} SET ${setClause} WHERE ${pkConditions.join(' AND ')}`;
+        const query = `UPDATE ${schemaName ? `${schemaName}.` : ''}${tableName} SET ${setClause} WHERE ${pkConditions.join(' AND ')}`;
 
         // Map parameters using original data keys to get correct values
         const params = updateKeys.map(key => data[key]);
@@ -379,7 +377,7 @@ export class LiteREST {
         // Sanitize column names
         const columns = dataKeys.map(col => this.sanitizeIdentifier(col));
         const setClause = columns.map(col => `${col} = ?`).join(', ');
-        const query = `UPDATE ${tableName} SET ${setClause} WHERE ${pkConditions.join(' AND ')}`;
+        const query = `UPDATE ${schemaName ? `${schemaName}.` : ''}${tableName} SET ${setClause} WHERE ${pkConditions.join(' AND ')}`;
 
         // Map parameters using original data keys to get correct values
         const params = dataKeys.map(key => data[key]);
@@ -406,7 +404,7 @@ export class LiteREST {
             return createResponse(undefined, error, 400);
         }
 
-        const query = `DELETE FROM ${tableName} WHERE ${pkConditions.join(' AND ')}`;
+        const query = `DELETE FROM ${schemaName ? `${schemaName}.` : ''}${tableName} WHERE ${pkConditions.join(' AND ')}`;
         const queries = [{ sql: query, params: pkParams }];
 
         try {

--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -179,8 +179,6 @@ export class LiteREST {
     }
 
     private async buildSelectQuery(tableName: string, id: string | undefined, searchParams: URLSearchParams): Promise<{ query: string, params: any[] }> {
-        console.log('Building SELECT Query');
-
         let query = `SELECT * FROM ${tableName}`;
         const params: any[] = [];
         const conditions: string[] = [];

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -55,7 +55,7 @@ export async function executeQuery(sql: string, params: any | undefined, isRaw: 
 
         let results: any = await response.json();
         let items = results.response.results?.items;
-        return this.afterQuery(sql, items, isRaw, dataSource);
+        return afterQuery(sql, items, isRaw, dataSource);
     } 
 }
 
@@ -92,7 +92,7 @@ export async function executeTransaction(queries: { sql: string; params?: any[] 
 
             const result: any = await response.json();
             const items = result.response.results?.items;
-            results.push(this.afterQuery(query.sql, items, isRaw, dataSource));
+            results.push(afterQuery(query.sql, items, isRaw, dataSource));
         }
 
         return results;

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,3 +1,4 @@
+import { DataSource, Source } from '.';
 import { createResponse } from './utils';
 
 export type OperationQueueItem = {
@@ -19,134 +20,32 @@ export type RawQueryResponse = {
 
 export type QueryResponse = any[] | RawQueryResponse;
 
-export function executeQuery(sql: string, params: any[] | undefined, isRaw: boolean, sqlInstance: any): QueryResponse {
-    try {
-        let cursor;
-        
-        if (params && params.length) {
-            cursor = sqlInstance.exec(sql, ...params);
-        } else {
-            cursor = sqlInstance.exec(sql);
+export async function executeQuery(sql: string, params: any[] | undefined, isRaw: boolean, dataSource: DataSource): Promise<QueryResponse> {
+    if (dataSource.source === 'internal') {
+        const response = await dataSource.internalConnection?.durableObject.executeQuery(sql, params, isRaw);
+        return response ?? [];
+    } else {
+        if (!dataSource.externalConnection) {
+            throw new Error('External connection not found.');
         }
 
-        let result;
+        // TODO: Can we try to handle `isRaw` here as well even though it's not supported by Outerbase?
 
-        if (isRaw) {
-            result = {
-                columns: cursor.columnNames,
-                rows: cursor.raw().toArray(),
-                meta: {
-                    rows_read: cursor.rowsRead,
-                    rows_written: cursor.rowsWritten,
-                },
-            };        
-        } else {
-            result = cursor.toArray();
-        }
-
-        return result;
-    } catch (error) {
-        console.error('SQL Execution Error:', error);
-        throw error;
-    }
-}
-
-export async function executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean, sqlInstance: any, ctx: any): Promise<any[]> {
-    return ctx.storage.transactionSync(() => {
-        const results = [];
-
-        try {
-            for (const queryObj of queries) {
-                const { sql, params } = queryObj;
-                const result = executeQuery(sql, params, isRaw, sqlInstance);
-                results.push(result);
-            }
-
-            return results;
-        } catch (error) {
-            console.error('Transaction Execution Error:', error);
-            throw error;
-        }
-    });
-}
-
-export async function enqueueOperation(
-    queries: { sql: string; params?: any[] }[],
-    isTransaction: boolean,
-    isRaw: boolean,
-    operationQueue: any[],
-    processNextOperation: () => Promise<void>
-): Promise<{ result?: any, error?: string | undefined, status: number }> {
-    const MAX_WAIT_TIME = 25000;
-    return new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-            reject(createResponse(undefined, 'Operation timed out.', 503));
-        }, MAX_WAIT_TIME);
-
-        operationQueue.push({
-            queries,
-            isTransaction,
-            isRaw,
-            resolve: (value: any) => {
-                clearTimeout(timeout);
-
-                resolve({
-                    result: value,
-                    error: undefined,
-                    status: 200
-                })
+        const API_URL = 'https://app.outerbase.com'
+        const response = await fetch(`${API_URL}/api/v1/ezql/raw`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Source-Token': dataSource.externalConnection.outerbaseApiKey,
             },
-            reject: (reason?: any) => {
-                clearTimeout(timeout);
+            body: JSON.stringify({
+                query: sql,
+                params: params,
+            }),
+        })
 
-                reject({
-                    result: undefined,
-                    error: reason ?? 'Operation failed.',
-                    status: 500
-                })
-            }
-        });
-
-        processNextOperation().catch((err) => {
-            console.error('Error processing operation queue:', err);
-        });
-    });
-}
-
-export async function processNextOperation(
-    sqlInstance: any,
-    operationQueue: OperationQueueItem[],
-    ctx: any,
-    processingOperation: { value: boolean }
-) {
-    if (processingOperation.value) {
-        // Already processing an operation
-        return;
-    }
-
-    if (operationQueue.length === 0) {
-        // No operations remaining to process
-        return;
-    }
-
-    processingOperation.value = true;
-    const { queries, isTransaction, isRaw, resolve, reject } = operationQueue.shift()!;
-
-    try {
-        let result;
-
-        if (isTransaction) {
-            result = await executeTransaction(queries, isRaw, sqlInstance, ctx);
-        } else {
-            const { sql, params } = queries[0];
-            result = executeQuery(sql, params, isRaw, sqlInstance);
-        }
-
-        resolve(result);
-    } catch (error: any) {
-        reject(error.message || 'Operation failed.');
-    } finally {
-        processingOperation.value = false;
-        await processNextOperation(sqlInstance, operationQueue, ctx, processingOperation);
-    }
+        let results: any = await response.json();
+        let items = results.response.results?.items;
+        return items;
+    } 
 }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -49,3 +49,18 @@ export async function executeQuery(sql: string, params: any[] | undefined, isRaw
         return items;
     } 
 }
+
+export async function executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean, dataSource: DataSource): Promise<QueryResponse> {
+    if (dataSource.source === 'internal') {
+        const response = await dataSource.internalConnection?.durableObject.executeTransaction(queries, isRaw);
+        return response ?? [];
+    } else {
+        if (!dataSource.externalConnection) {
+            throw new Error('External connection not found.');
+        }
+
+        // TODO: Implement transaction for external source
+    }
+
+    return [];
+}

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,4 +1,5 @@
 import { DataSource } from '.';
+import { Env } from './'
 
 export type OperationQueueItem = {
     queries: { sql: string; params?: any[] }[];
@@ -19,13 +20,56 @@ export type RawQueryResponse = {
 
 export type QueryResponse = any[] | RawQueryResponse;
 
-async function afterQuery(sql: string, result: any, isRaw: boolean, dataSource?: DataSource): Promise<any> {
+async function afterQuery(sql: string, result: any, isRaw: boolean, dataSource?: DataSource, env?: Env): Promise<any> {
     // ## DO NOT REMOVE: TEMPLATE AFTER QUERY HOOK ##
 
     return result;
 }
 
-export async function executeQuery(sql: string, params: any | undefined, isRaw: boolean, dataSource?: DataSource): Promise<QueryResponse> {
+function cleanseQuery(sql: string): string {
+    return sql.replaceAll('\n', ' ')
+}
+
+ // NOTE: This is a temporary stop-gap solution to connect to external data sources. Outerbase offers
+ // an API to handle connecting to a large number of database types in a secure manner. However, the
+ // goal here is to optimize on query latency from your data sources by connecting to them directly.
+ // An upcoming update will move the Outerbase SDK to be used in StarbaseDB so this service can connect
+// to those database types without being required to funnel requests through the Outerbase API.
+async function executeExternalQuery(sql: string, params: any, isRaw: boolean, dataSource: DataSource, env?: Env): Promise<any> {
+    if (!dataSource.externalConnection) {
+        throw new Error('External connection not found.');
+    }
+
+    // Convert params from array to object if needed
+    let convertedParams = params;
+    if (Array.isArray(params)) {
+        let paramIndex = 0;
+        convertedParams = params.reduce((acc, value, index) => ({
+            ...acc,
+            [`param${index}`]: value
+        }), {});
+        sql = sql.replace(/\?/g, () => `:param${paramIndex++}`);
+    }
+
+    const API_URL = 'https://app.outerbase.com';
+    const response = await fetch(`${API_URL}/api/v1/ezql/raw`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Source-Token': dataSource.externalConnection.outerbaseApiKey,
+        },
+        body: JSON.stringify({
+            query: cleanseQuery(sql),
+            params: convertedParams,
+        }),
+    });
+
+    const results: any = await response.json();
+    const items = results.response.results?.items;
+    return await afterQuery(sql, items, isRaw, dataSource, env);
+}
+
+export async function executeQuery(sql: string, params: any | undefined, isRaw: boolean, dataSource?: DataSource, env?: Env): Promise<QueryResponse> {
     if (!dataSource) {
         console.error('Data source not found.')
         return []
@@ -33,68 +77,40 @@ export async function executeQuery(sql: string, params: any | undefined, isRaw: 
 
     if (dataSource.source === 'internal') {
         const response = await dataSource.internalConnection?.durableObject.executeQuery(sql, params, isRaw);
-        return response ?? [];
+        return await afterQuery(sql, response, isRaw, dataSource, env);
     } else {
-        if (!dataSource.externalConnection) {
-            throw new Error('External connection not found.');
-        }
-
-        const API_URL = 'https://app.outerbase.com'
-        const response = await fetch(`${API_URL}/api/v1/ezql/raw`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Source-Token': dataSource.externalConnection.outerbaseApiKey,
-            },
-            body: JSON.stringify({
-                query: sql,
-                // Params does not support arrays, so we ensure we only pass them an object.
-                params: Array.isArray(params) ? {} : params,
-            }),
-        })
-
-        let results: any = await response.json();
-        let items = results.response.results?.items;
-        return afterQuery(sql, items, isRaw, dataSource);
-    } 
+        return executeExternalQuery(sql, params, isRaw, dataSource, env);
+    }
 }
 
-export async function executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean, dataSource?: DataSource): Promise<QueryResponse> {
+export async function executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean, dataSource?: DataSource, env?: Env): Promise<QueryResponse> {
     if (!dataSource) {
         console.error('Data source not found.')
         return []
     }
     
     if (dataSource.source === 'internal') {
-        const response = await dataSource.internalConnection?.durableObject.executeTransaction(queries, isRaw);
-        return response ?? [];
-    } else {
-        if (!dataSource.externalConnection) {
-            throw new Error('External connection not found.');
-        }
+        const results: any[] = [];
 
-        const API_URL = 'https://app.outerbase.com';
+        for (const query of queries) {
+            const result = await dataSource.internalConnection?.durableObject.executeTransaction(queries, isRaw);
+            if (result) {
+                const processedResults = await Promise.all(
+                    result.map(r => afterQuery(query.sql, r, isRaw, dataSource, env))
+                );
+                results.push(...processedResults);
+            }
+        }
+        
+        return results;
+    } else {
         const results = [];
 
         for (const query of queries) {
-            const response = await fetch(`${API_URL}/api/v1/ezql/raw`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Source-Token': dataSource.externalConnection.outerbaseApiKey,
-                },
-                body: JSON.stringify({
-                    query: query.sql,
-                    // Params does not support arrays, so we ensure we only pass them an object
-                    params: Array.isArray(query.params) ? {} : query.params,
-                }),
-            });
-
-            const result: any = await response.json();
-            const items = result.response.results?.items;
-            results.push(afterQuery(query.sql, items, isRaw, dataSource));
+            const result = await executeExternalQuery(query.sql, query.params, isRaw, dataSource, env);
+            results.push(result);
         }
-
+        
         return results;
     }
 }

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -3,7 +3,5 @@
 interface Env {
 	AUTHORIZATION_TOKEN: "ABC123";
 	REGION: "auto";
-	EXTERNAL_DB_TYPE: "postgres";
-	OUTERBASE_API_KEY: "";
 	DATABASE_DURABLE_OBJECT: DurableObjectNamespace<import("./src/index").DatabaseDurableObject>;
 }

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -2,5 +2,11 @@
 
 interface Env {
 	AUTHORIZATION_TOKEN: "ABC123";
+	EXTERNAL_DB_TYPE: "postgres";
+	EXTERNAL_DB_HOST: "";
+	EXTERNAL_DB_NAME: "";
+	EXTERNAL_DB_USER: "";
+	EXTERNAL_DB_PASS: "";
+	EXTERNAL_DB_PORT: "0";
 	DATABASE_DURABLE_OBJECT: DurableObjectNamespace<import("./src/index").DatabaseDurableObject>;
 }

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -2,11 +2,8 @@
 
 interface Env {
 	AUTHORIZATION_TOKEN: "ABC123";
+	REGION: "auto";
 	EXTERNAL_DB_TYPE: "postgres";
-	EXTERNAL_DB_HOST: "";
-	EXTERNAL_DB_NAME: "";
-	EXTERNAL_DB_USER: "";
-	EXTERNAL_DB_PASS: "";
-	EXTERNAL_DB_PORT: "0";
+	OUTERBASE_API_KEY: "";
 	DATABASE_DURABLE_OBJECT: DurableObjectNamespace<import("./src/index").DatabaseDurableObject>;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,8 +38,4 @@ REGION = "auto"
 # External database source details
 # This enables Starbase to connect to an external data source
 EXTERNAL_DB_TYPE = "postgres"
-EXTERNAL_DB_HOST = ""
-EXTERNAL_DB_NAME = ""
-EXTERNAL_DB_USER = ""
-EXTERNAL_DB_PASS = ""
-EXTERNAL_DB_PORT = "0"
+OUTERBASE_API_KEY = ""

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -33,3 +33,12 @@ AUTHORIZATION_TOKEN = "ABC123"
 # You can access the Studio UI at: https://your_endpoint/studio
 # STUDIO_USER = "admin"
 # STUDIO_PASS = "123456"
+
+# External database source details
+# This enables Starbase to connect to an external data source
+EXTERNAL_DB_TYPE = "postgres"
+EXTERNAL_DB_HOST = ""
+EXTERNAL_DB_NAME = ""
+EXTERNAL_DB_USER = ""
+EXTERNAL_DB_PASS = ""
+EXTERNAL_DB_PORT = "0"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -37,5 +37,5 @@ REGION = "auto"
 
 # External database source details
 # This enables Starbase to connect to an external data source
-EXTERNAL_DB_TYPE = "postgres"
-OUTERBASE_API_KEY = ""
+# EXTERNAL_DB_TYPE = "postgres"
+# OUTERBASE_API_KEY = ""


### PR DESCRIPTION
## Purpose
A majority of this pull request is suggesting that we move most of the code out of the Durable Object and into the Worker so that the entire idea of supporting both an `internal` and `external` database connection can easily co-exist. There are plenty of data stores out there today that act as an independent database for both SQLite and others, but my current line of thinking is StarbaseDB could _really_ thrive as a co-op database to attach to any already existing database rather than standalone (but it would still work as standalone, too!).

For one – there are far more use cases to "supercharge" existing databases today rather than providing just another start-from-new SQLite offering.

Why would we want an internal & external data source attached to a StarbaseDB you may ask? What if StarbaseDB could "attach" to any pre-existing data source to help with operations such as:

1.  Query caching on the edge (get results from external, store in internal SQLite)
2. Dynamic data masking (utilize the compute aspect prior to returning data)
3. Easy, low-risk methods to build alongside existing database (some tables in internal, some in external)
4. Run operations on any data source at intervals (CRON timers)
5. Get core functionality out of the box to use against existing databases such as REST API, Web Sockets, etc.
6. More... but maybe you're getting the gist by now?

_NOTE: In an upcoming pull request we will migrate the logical aspect of connecting an external database so in the best case scenario it is using native database drivers (e.g. Postgres, MySQL, etc) and not channeling through a hosted API. The hosted API does provide some benefit for _some_ data sources for things such as private connections and more so currently it is planned for it to continue to exist in the future as well._

## Tasks
<!-- [ ] incomplete; [x] complete -->

- [x] Continue supporting StarbaseDB as a standalone SQLite database
- [x] Allow you to connect an "external" database (currently only via Outerbase API token in this PR)
- [x] Move most of the logic away from the Durable Object and into the Worker
- [x] Test all functionality still works as previously did

## Verify
<!-- guidance or steps to assist the reviewer -->

- Query both internal and external data sources
- Transaction queries on both internal and external data sources
- REST API works on both internal and external data sources
- Web Socket querying works on both internal and external data sources
- Import data into internal data source
- Export data from internal data source
- Verify auth template still works as intended
- Verify Outerbase UI interface works as intended

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->