### PR TITLE
beforeQuery functional hook

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,4 +1,4 @@
-import { DataSource, Source } from ".";
+import { DataSource, Source } from "./types";
 import { LiteREST } from "./literest";
 import { executeQuery, executeTransaction } from "./operation";
 import { createResponse, QueryRequest, QueryTransactionRequest } from "./utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { createResponse } from './utils';
 import handleStudioRequest from "./studio";
 import { Handler } from "./handler";
-import { QueryResponse } from "./operation";
+import { DatabaseStub, DataSource, RegionLocationHint, Source } from './types';
 export { DatabaseDurableObject } from './do'; 
 
 const DURABLE_OBJECT_ID = 'sql-durable-object';
@@ -35,43 +35,9 @@ export interface Env {
     EXTERNAL_DB_CLOUDFLARE_DATABASE_ID?: string;
   
     // ## DO NOT REMOVE: TEMPLATE INTERFACE ##
-}
-
-export enum Source {
-    internal = 'internal',  // Durable Object's SQLite instance
-    external = 'external'   // External data source (e.g. Outerbase)
-}
-
-export type DataSource = {
-    source: Source;
-    request: Request;
-    internalConnection?: InternalConnection;
-    externalConnection?: {
-        outerbaseApiKey: string;
-    };
-}
-
-interface InternalConnection {
-    durableObject: DatabaseStub;
-}
-
-type DatabaseStub = DurableObjectStub & {
-    fetch: (init?: RequestInit | Request) => Promise<Response>;
-    executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse;
-    executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean): any[];
-};
-
-enum RegionLocationHint {
-    AUTO = 'auto',
-    WNAM = 'wnam', // Western North America
-    ENAM = 'enam', // Eastern North America
-    SAM = 'sam', // South America
-    WEUR = 'weur', // Western Europe
-    EEUR = 'eeur', // Eastern Europe
-    APAC = 'apac', // Asia Pacific
-    OC = 'oc', // Oceania
-    AFR = 'afr', // Africa
-    ME = 'me', // Middle East
+    RLS: {
+        applyRLS(sql: string, dialect?: string): Promise<string | Error>
+    }
 }
 
 export default {
@@ -84,67 +50,73 @@ export default {
 	 * @returns The response to be sent back to the client
 	 */
 	async fetch(request, env, ctx): Promise<Response> {
-        const url = new URL(request.url);
-        const pathname = url.pathname;
-        const isWebSocket = request.headers.get("Upgrade") === "websocket";
+        try {
+            const url = new URL(request.url);
+            const pathname = url.pathname;
+            const isWebSocket = request.headers.get("Upgrade") === "websocket";
 
-        /**
-         * If the request is a GET request to the /studio endpoint, we can handle the request
-         * directly in the Worker to avoid the need to deploy a separate Worker for the Studio.
-         * Studio provides a user interface to interact with the SQLite database in the Durable
-         * Object.
-         */
-        if (env.STUDIO_USER && env.STUDIO_PASS && request.method === 'GET' && pathname === '/studio') {
-            return handleStudioRequest(request, {
-                username: env.STUDIO_USER,
-                password: env.STUDIO_PASS, 
-                apiToken: env.AUTHORIZATION_TOKEN
-            });
-        }
-
-        /**
-         * Prior to proceeding to the Durable Object, we can perform any necessary validation or
-         * authorization checks here to ensure the request signature is valid and authorized to
-         * interact with the Durable Object.
-         */
-        if (request.headers.get('Authorization') !== `Bearer ${env.AUTHORIZATION_TOKEN}` && !isWebSocket) {
-            return createResponse(undefined, 'Unauthorized request', 401)
-        } else if (isWebSocket) {
             /**
-             * Web socket connections cannot pass in an Authorization header into their requests,
-             * so we can use a query parameter to validate the connection.
+             * If the request is a GET request to the /studio endpoint, we can handle the request
+             * directly in the Worker to avoid the need to deploy a separate Worker for the Studio.
+             * Studio provides a user interface to interact with the SQLite database in the Durable
+             * Object.
              */
-            const token = url.searchParams.get('token');
-
-            if (token !== env.AUTHORIZATION_TOKEN) {
-                return new Response('WebSocket connections are not supported at this endpoint.', { status: 440 });
+            if (env.STUDIO_USER && env.STUDIO_PASS && request.method === 'GET' && pathname === '/studio') {
+                return handleStudioRequest(request, {
+                    username: env.STUDIO_USER,
+                    password: env.STUDIO_PASS, 
+                    apiToken: env.AUTHORIZATION_TOKEN
+                });
             }
+
+            /**
+             * Prior to proceeding to the Durable Object, we can perform any necessary validation or
+             * authorization checks here to ensure the request signature is valid and authorized to
+             * interact with the Durable Object.
+             */
+            if (request.headers.get('Authorization') !== `Bearer ${env.AUTHORIZATION_TOKEN}` && !isWebSocket) {
+                return createResponse(undefined, 'Unauthorized request', 401)
+            } else if (isWebSocket) {
+                /**
+                 * Web socket connections cannot pass in an Authorization header into their requests,
+                 * so we can use a query parameter to validate the connection.
+                 */
+                const token = url.searchParams.get('token');
+
+                if (token !== env.AUTHORIZATION_TOKEN) {
+                    return new Response('WebSocket connections are not supported at this endpoint.', { status: 440 });
+                }
+            }
+
+            /**
+             * Retrieve the Durable Object identifier from the environment bindings and instantiate a
+             * Durable Object stub to interact with the Durable Object.
+             */
+            const region = env.REGION ?? RegionLocationHint.AUTO;
+            const id: DurableObjectId = env.DATABASE_DURABLE_OBJECT.idFromName(DURABLE_OBJECT_ID);
+            const stub = region !== RegionLocationHint.AUTO ? env.DATABASE_DURABLE_OBJECT.get(id, { locationHint: region as DurableObjectLocationHint }) : env.DATABASE_DURABLE_OBJECT.get(id);
+
+            const source: Source = request.headers.get('X-Starbase-Source') as Source ?? url.searchParams.get('source') as Source ?? 'internal';
+            const dataSource: DataSource = {
+                source: source,
+                request: request.clone(),
+                internalConnection: {
+                    durableObject: stub as unknown as DatabaseStub,
+                },
+                externalConnection: {
+                    outerbaseApiKey: env.OUTERBASE_API_KEY ?? ''
+                }
+            };
+
+            const response = await new Handler().handle(request, dataSource, env);
+            return response;
+        } catch (error) {
+            // Return error response to client
+            return createResponse(
+                undefined, 
+                error instanceof Error ? error.message : 'An unexpected error occurred',
+                400
+            );
         }
-
-        /**
-         * Retrieve the Durable Object identifier from the environment bindings and instantiate a
-         * Durable Object stub to interact with the Durable Object.
-         */
-        const region = env.REGION ?? RegionLocationHint.AUTO;
-        const id: DurableObjectId = env.DATABASE_DURABLE_OBJECT.idFromName(DURABLE_OBJECT_ID);
-        const stub = region !== RegionLocationHint.AUTO ? env.DATABASE_DURABLE_OBJECT.get(id, { locationHint: region as DurableObjectLocationHint }) : env.DATABASE_DURABLE_OBJECT.get(id);
-
-        const source: Source = request.headers.get('X-Starbase-Source') as Source ?? url.searchParams.get('source') as Source ?? 'internal';
-        const dataSource: DataSource = {
-            source: source,
-            request: request.clone(),
-            internalConnection: {
-                durableObject: stub as unknown as DatabaseStub,
-            },
-            externalConnection: {
-                outerbaseApiKey: env.OUTERBASE_API_KEY ?? ''
-            }
-        };
-
-        const response = await new Handler().handle(request, dataSource, env);
-
-        // ## DO NOT REMOVE: TEMPLATE ROUTING ##
-
-        return response;
 	},
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,6 @@ export interface Env {
     EXTERNAL_DB_CLOUDFLARE_DATABASE_ID?: string;
   
     // ## DO NOT REMOVE: TEMPLATE INTERFACE ##
-    RLS: {
-        applyRLS(sql: string, dialect?: string): Promise<string | Error>
-    }
 }
 
 export default {

--- a/src/literest/index.ts
+++ b/src/literest/index.ts
@@ -1,5 +1,5 @@
 import { createResponse } from '../utils';
-import { DataSource, Source } from "..";
+import { DataSource, Source } from "../types";
 import { executeQuery, executeTransaction } from "../operation";
 import { Env } from "../index"
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -48,10 +48,6 @@ async function afterQuery(sql: string, result: any, isRaw: boolean, dataSource?:
     return result;
 }
 
-function cleanseQuery(sql: string): string {
-    return sql.replaceAll('\n', ' ')
-}
-
 // Outerbase API supports more data sources than can be supported via Cloudflare Workers. For those data
 // sources we recommend you connect your database to Outerbase and provide the bases API key for queries
 // to be made. Otherwise, for supported data sources such as Postgres, MySQL, D1, StarbaseDB, Turso and Mongo
@@ -86,7 +82,7 @@ async function executeExternalQuery(sql: string, params: any, isRaw: boolean, da
             'X-Source-Token': dataSource.externalConnection.outerbaseApiKey,
         },
         body: JSON.stringify({
-            query: cleanseQuery(sql),
+            query: sql.replaceAll('\n', ' '),
             params: convertedParams,
         }),
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,38 @@
+import { QueryResponse } from "./operation";
+
+export enum Source {
+    internal = 'internal',  // Durable Object's SQLite instance
+    external = 'external'   // External data source (e.g. Outerbase)
+}
+
+export type DataSource = {
+    source: Source;
+    request: Request;
+    internalConnection?: InternalConnection;
+    externalConnection?: {
+        outerbaseApiKey: string;
+    };
+}
+
+export interface InternalConnection {
+    durableObject: DatabaseStub;
+}
+
+export type DatabaseStub = DurableObjectStub & {
+    fetch: (init?: RequestInit | Request) => Promise<Response>;
+    executeQuery(sql: string, params: any[] | undefined, isRaw: boolean): QueryResponse;
+    executeTransaction(queries: { sql: string; params?: any[] }[], isRaw: boolean): any[];
+};
+
+export enum RegionLocationHint {
+    AUTO = 'auto',
+    WNAM = 'wnam', // Western North America
+    ENAM = 'enam', // Eastern North America
+    SAM = 'sam', // South America
+    WEUR = 'weur', // Western Europe
+    EEUR = 'eeur', // Eastern Europe
+    APAC = 'apac', // Asia Pacific
+    OC = 'oc', // Oceania
+    AFR = 'afr', // Africa
+    ME = 'me', // Middle East
+}


### PR DESCRIPTION
## Purpose
Support a `beforeQuery` hook where all SQL queries prior to being executed against the database run through a series of operations (an empty array by default) to either validate, transform, or any other potential operation and returning either the same or an updated SQL statement back.


## Tasks
<!-- [ ] incomplete; [x] complete -->

- [X] Add a `beforeQuery` hook similar to the already existing `afterQuery`
- [X] Move shared types to a `types.ts` file
- [X] Remove redundant code for transactions executing queries

## Verify
<!-- guidance or steps to assist the reviewer -->

- 

## Before
<!-- screenshot before changes -->



## After
<!-- screenshot after changes -->